### PR TITLE
Fixed spelling error 'paymeny' -> 'payment' in Pay by Stripe Connect section

### DIFF
--- a/payments/paying-for-an-order/stripe-payments.md
+++ b/payments/paying-for-an-order/stripe-payments.md
@@ -338,7 +338,7 @@ const id = 'XXXX'
 const payment = {
   gateway: 'stripe',
   method: 'purchase',
-  paymeny: 'tok_visa'
+  payment: 'tok_visa'
   options: {
     destination: 'acct_XXX'
   }
@@ -350,4 +350,3 @@ Moltin.Orders.Payment(id, order).then(() => {
 ```
 {% endtab %}
 {% endtabs %}
-


### PR DESCRIPTION
Fixed spelling error 'paymeny' -> 'payment' in [Pay by Stripe Connect](https://docs.moltin.com/payments/paying-for-an-order/stripe-payments#pay-by-stripe-connect) section.|