### PR TITLE
Moltin.Customers.Token receives two arguments

### DIFF
--- a/orders-and-customers/customers/customer-tokens.md
+++ b/orders-and-customers/customers/customer-tokens.md
@@ -108,12 +108,10 @@ const Moltin = MoltinGateway({
   client_id: 'X'
 })
 
-const customer = {
-  email: 'ron@swanson.com',
-  password: 'mysecretpassword'
-}
+const email = 'ron@swanson.com';
+const password = 'mysecretpassword';
 
-Moltin.Customers.Token(customer).then(data => {
+Moltin.Customers.Token(email,password).then(data => {
   // Do something
 })
 ```


### PR DESCRIPTION
The Moltin.Customers.Token function do not accept customer object, instead it takes email and password as first and second argument respectively.