### PR TITLE
Change javascript SDK examples to use main-image

### DIFF
--- a/catalog/products/relationships/main-image-relationship.md
+++ b/catalog/products/relationships/main-image-relationship.md
@@ -81,7 +81,7 @@ const Moltin = MoltinGateway({
 
 const productId = 'XXXX'
 
-Moltin.Products.CreateRelationships(productId, 'main_image', '98df7738-febe-4987-bc0e-b857297b30e9').then((relationships) => {
+Moltin.Products.CreateRelationships(productId, 'main-image', '98df7738-febe-4987-bc0e-b857297b30e9').then((relationships) => {
   // Do something
 })
 ```
@@ -169,7 +169,7 @@ const Moltin = MoltinGateway({
 
 const productId = 'XXXX'
 
-Moltin.Products.UpdateRelationships(productId, 'main_image', 'e9737dc6-876a-4eab-b3b7-af62a1999123').then((relationships) => {
+Moltin.Products.UpdateRelationships(productId, 'main-image', 'e9737dc6-876a-4eab-b3b7-af62a1999123').then((relationships) => {
   // Do something
 })
 ```
@@ -250,7 +250,7 @@ const Moltin = MoltinGateway({
 
 const productId = 'XXXX'
 
-Moltin.Products.DeleteRelationships(productId, 'main_image', 'e9737dc6-876a-4eab-b3b7-af62a1999123').then((relationships) => {
+Moltin.Products.DeleteRelationships(productId, 'main-image', 'e9737dc6-876a-4eab-b3b7-af62a1999123').then((relationships) => {
   // Do something
 })
 ```


### PR DESCRIPTION
The docs show examples using main_image, however this doesn't actually work because of how CreateRelationships et al work under the hood. However main-image does, so lets change the docs to reflect this.

This has cost me a good few hours so I don't want others to fall prey to the same accident!