### PR TITLE
Typo fix in JS SDK examples

### DIFF
--- a/payments/paying-for-an-order/stripe-payments.md
+++ b/payments/paying-for-an-order/stripe-payments.md
@@ -133,7 +133,7 @@ const payment = {
   payment: 'tok_visa'
 }
 
-Moltin.Orders.Payment(id, order).then(() => {
+Moltin.Orders.Payment(id, payment).then(() => {
   // Do something
 })
 ```
@@ -305,7 +305,7 @@ const payment = {
   verification_value: "123"
 }
 
-Moltin.Orders.Payment(id, order).then(() => {
+Moltin.Orders.Payment(id, payment).then(() => {
   // Do something
 })
 ```
@@ -437,7 +437,7 @@ const payment = {
   }
 }
 
-Moltin.Orders.Payment(id, order).then(() => {
+Moltin.Orders.Payment(id, payment).then(() => {
   // Do something
 })
 ```


### PR DESCRIPTION
JS SDK example for 
Moltin.Orders.Payment(id, order).then(() => {
should be
Moltin.Orders.Payment(id, payment).then(() => {